### PR TITLE
changes to create a statefull localLoginService

### DIFF
--- a/packages/flutter_login_service/CHANGELOG.md
+++ b/packages/flutter_login_service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0
+
+* Made the localLoginService statefull.
+
 ## 3.0.0
 
 * Renamed the login interface "LoginService" to "LoginServiceInterface".

--- a/packages/flutter_login_service/lib/src/login_service.dart
+++ b/packages/flutter_login_service/lib/src/login_service.dart
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import 'package:flutter/material.dart';
+import 'package:flutter_login_service/flutter_login_service.dart';
 import 'package:flutter_login_service/src/models/models.dart';
 
 /// A service to handle authentication.
@@ -34,14 +35,25 @@ abstract class LoginServiceInterface {
   /// [logout] is used to log out the currently logged in user.
   Future<bool> logout(BuildContext context);
 
+  /// [isLoggedIn] is use to check to see if current user is logged in.
+  Future<bool> isLoggedIn();
+
   /// [getLoggedInUser] is used to get the currently logged in user.
   Future getLoggedInUser();
 }
 
 /// A local login service for testing purposes.
 class LocalLoginService implements LoginServiceInterface {
+  factory LocalLoginService() => _instance;
+
+  bool loggedIn = false;
+  dynamic userObject;
+
+  // singleton reference to keep state
+  static final LocalLoginService _instance = LocalLoginService();
+
   @override
-  Future getLoggedInUser() async => true;
+  Future getLoggedInUser() async => userObject;
 
   @override
   Future<LoginResponse> loginWithEmailAndPassword(
@@ -50,11 +62,21 @@ class LocalLoginService implements LoginServiceInterface {
     BuildContext context, {
     // ignore: avoid_annotating_with_dynamic
     Function(dynamic resolver)? onMFA,
-  }) async =>
-      const LoginResponse(loginSuccessful: true, userObject: null);
+  }) async {
+    loggedIn = true;
+    userObject = {'name': 'John Doe'};
+    return LoginResponse(
+      loginSuccessful: loggedIn,
+      userObject: userObject,
+    );
+  }
 
   @override
-  Future<bool> logout(BuildContext context) async => true;
+  Future<bool> logout(BuildContext context) async {
+    loggedIn = false;
+    userObject = null;
+    return true;
+  }
 
   @override
   Future<RequestPasswordResponse> requestChangePassword(
@@ -64,4 +86,7 @@ class LocalLoginService implements LoginServiceInterface {
       const RequestPasswordResponse(
         requestSuccesfull: true,
       );
+
+  @override
+  Future<bool> isLoggedIn() async => loggedIn;
 }

--- a/packages/flutter_login_service/pubspec.yaml
+++ b/packages/flutter_login_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_login_service
 description: A new Flutter package project.
-version: 3.0.0
+version: 4.0.0
 homepage: https://github.com/Iconica-Development
 publish_to: none
 


### PR DESCRIPTION
Added code to give the LocalLoginService a statefull implementation. This gives the opportunity to add state-dependent widget to be developed and tested in the flutter_user userstory.